### PR TITLE
Adding deprecations

### DIFF
--- a/lib/LongitudeOne/Geo/WKT/Lexer.php
+++ b/lib/LongitudeOne/Geo/WKT/Lexer.php
@@ -56,13 +56,35 @@ class Lexer extends AbstractLexer
     public const T_ZM = 501;
 
     /**
-     * @param string $input a query string
+     * @param string|int|float $input a query string
      */
     public function __construct($input = null)
     {
-        if (null !== $input) {
-            $this->setInput($input);
+        if (!is_null($input) && !is_string($input)) {
+            trigger_error(
+                'Since longitudeone/wkt-parser 2.1: Passing a float or an integer to LongitudeOne\WKT\String\Lexer::__construct() is deprecated. Use a string instead.',
+                E_USER_DEPRECATED
+            );
         }
+
+        if (null !== $input) {
+            $this->setInput((string) $input);
+        }
+    }
+
+    /**
+     * @param ?string $input
+     */
+    public function setInput($input): void
+    {
+        if (!is_null($input) && !is_string($input)) {
+            trigger_error(
+                'Since longitudeone/wkt-parser 2.1: Passing a float or an integer to LongitudeOne\WKT\String\Lexer::setInput() is deprecated. Use a string instead.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        parent::setInput((string) $input);
     }
 
     public function value(): int|float|string

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" colors="true"
-         bootstrap="./vendor/autoload.php" cacheDirectory=".phpunit.cache">
+         bootstrap="./vendor/autoload.php" cacheDirectory=".phpunit.cache"
+        displayDetailsOnTestsThatTriggerDeprecations="true">
     <testsuites>
         <testsuite name="Tests">
             <directory>./tests/LongitudeOne/Geo/WKT/Tests</directory>

--- a/quality/php-mess-detector/codeclimate-ruleset.xml
+++ b/quality/php-mess-detector/codeclimate-ruleset.xml
@@ -11,6 +11,7 @@
     <rule ref="rulesets/unusedcode.xml" />
     <!-- Import the entire codeside rule -->
     <rule ref="rulesets/codesize.xml">
+        <!-- Exclude the ExcessiveMethodLength rule, because there are never too many tests in provider -->
         <exclude name="ExcessiveMethodLength"/>
         <!-- Exclude the TooManyPublicMethods rule, because there are never too many tests -->
         <exclude name="TooManyPublicMethods"/>

--- a/quality/php-mess-detector/test-ruleset.xml
+++ b/quality/php-mess-detector/test-ruleset.xml
@@ -11,14 +11,10 @@
     <rule ref="rulesets/unusedcode.xml" />
     <!-- Import the entire codeside rule -->
     <rule ref="rulesets/codesize.xml">
+        <!-- Exclude the ExcessiveMethodLength rule, because there are never too many tests in provider -->
         <exclude name="ExcessiveMethodLength"/>
         <!-- Exclude the TooManyPublicMethods rule, because there are never too many tests -->
         <exclude name="TooManyPublicMethods"/>
-    </rule>
-    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
-        <properties>
-            <property name="minimum" value="102"/>
-        </properties>
     </rule>
     <!-- Import the entire naming rule set -->
     <rule ref="rulesets/naming.xml" />

--- a/quality/php-stan/phpstan-baseline.neon
+++ b/quality/php-stan/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: ../../lib/LongitudeOne/Geo/WKT/Lexer.php
 
 		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: ../../lib/LongitudeOne/Geo/WKT/Lexer.php
+
+		-
 			message: "#^Type float\\|int\\|string in generic type Doctrine\\\\Common\\\\Lexer\\\\AbstractLexer\\<int, float\\|int\\|string\\> in PHPDoc tag @extends is not subtype of template type V of int\\|string of class Doctrine\\\\Common\\\\Lexer\\\\AbstractLexer\\.$#"
 			count: 1
 			path: ../../lib/LongitudeOne/Geo/WKT/Lexer.php

--- a/tests/LongitudeOne/Geo/WKT/Tests/LexerTest.php
+++ b/tests/LongitudeOne/Geo/WKT/Tests/LexerTest.php
@@ -99,6 +99,7 @@ class LexerTest extends TestCase
         yield '-25' => ['-25', [[Lexer::T_INTEGER, -25, 0]]];
         yield '-120.33' => ['-120.33', [[Lexer::T_FLOAT, -120.33, 0]]];
         yield '0.0' => ['0.0', [[Lexer::T_FLOAT, 0.0, 0]]];
+        yield '1e-5' => ['1e-5', [[Lexer::T_FLOAT, 0.00001, 0]]];
 
         yield 'SRID' => ['SRID', [[Lexer::T_SRID, 'SRID', 0]]];
         yield 'SRID=4326;LINESTRING(0 0.0, 10.1 -10.025, 20.5 25.9, 53E-003 60)' => [


### PR DESCRIPTION
Using a non-string value is now deprecated with Lexer.