### PR TITLE
Fix issue #8 The ctype_alpha function could be avoid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-ctype": "*",
         "doctrine/lexer": "^2.1"
     },
     "require-dev": {

--- a/lib/LongitudeOne/Geo/WKT/Exception/NotYetImplementedException.php
+++ b/lib/LongitudeOne/Geo/WKT/Exception/NotYetImplementedException.php
@@ -23,7 +23,8 @@ final class NotYetImplementedException extends \LogicException implements Except
 {
     public function __construct(string $message, int $code = 0, ?\Throwable $previous = null)
     {
-        $finalMessage = sprintf('The %s is not yet able to parse %s.',
+        $finalMessage = sprintf(
+            'The %s is not yet able to parse %s.',
             Parser::class,
             $message
         );

--- a/lib/LongitudeOne/Geo/WKT/Lexer.php
+++ b/lib/LongitudeOne/Geo/WKT/Lexer.php
@@ -127,7 +127,7 @@ class Lexer extends AbstractLexer
             return self::T_FLOAT;
         }
 
-        if (ctype_alpha($value)) {
+        if (preg_match('/^[a-zA-Z]+$/', $value)) {
             $name = __CLASS__.'::T_'.strtoupper($value);
 
             if (defined($name) && is_int(constant($name))) {


### PR DESCRIPTION
✅ issue https://github.com/longitude-one/wkt-parser/issues/8 fixed
✅ `ext-ctype` dependency in composer.json : not useful anymore
✅ minor formating fix in `lib/LongitudeOne/Geo/WKT/Exception/NotYetImplementedException.php` (via cs fixer)

